### PR TITLE
eliminates typing errors on existing code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _build
+**/*.js
 node_modules
 **/node_modules

--- a/dijit/1.11/form.d.ts
+++ b/dijit/1.11/form.d.ts
@@ -1,8 +1,8 @@
 declare namespace dijit {
 
-    interface ToolbarSeparator {
-        (): any;
-    }
+	interface ToolbarSeparator {
+		(): any;
+	}
 
 	namespace form {
 

--- a/dijit/1.11/form.d.ts
+++ b/dijit/1.11/form.d.ts
@@ -1,5 +1,9 @@
 declare namespace dijit {
 
+    interface ToolbarSeparator {
+        (): any;
+    }
+
 	namespace form {
 
 		/* implied */

--- a/dijit/1.11/layout.d.ts
+++ b/dijit/1.11/layout.d.ts
@@ -1,10 +1,10 @@
 declare namespace dijit {
 
-    interface TitlePane extends layout.ContentPane {
-        titleNode: any;
-    }
-    
-    interface TitlePaneConstructor extends _WidgetBaseConstructor<TitlePane> { }
+	interface TitlePane extends layout.ContentPane {
+		titleNode: any;
+	}
+
+	interface TitlePaneConstructor extends _WidgetBaseConstructor<TitlePane> { }
 
 	namespace layout {
 
@@ -668,7 +668,7 @@ declare namespace dijit {
 		}
 
 		interface TabControllerConstructor extends _WidgetBaseConstructor<TabController> { }
-        
+
 	}
 }
 

--- a/dijit/1.11/layout.d.ts
+++ b/dijit/1.11/layout.d.ts
@@ -1,5 +1,11 @@
 declare namespace dijit {
 
+    interface TitlePane extends layout.ContentPane {
+        titleNode: any;
+    }
+    
+    interface TitlePaneConstructor extends _WidgetBaseConstructor<TitlePane> { }
+
 	namespace layout {
 
 		/* dijit/_LayoutWidget */
@@ -662,5 +668,7 @@ declare namespace dijit {
 		}
 
 		interface TabControllerConstructor extends _WidgetBaseConstructor<TabController> { }
+        
 	}
 }
+

--- a/dijit/1.11/modules.d.ts
+++ b/dijit/1.11/modules.d.ts
@@ -206,13 +206,13 @@ declare module 'dijit/layout/TabController' {
 }
 
 declare module 'dijit/TitlePane' {
-    const TitlePane: dijit.TitlePaneConstructor;
-    export = TitlePane;
+	const TitlePane: dijit.TitlePaneConstructor;
+	export = TitlePane;
 }
 
 declare module 'dijit/ToolbarSeparator' {
-    const x: dijit.ToolbarSeparator;
-    export = x;
+	const x: dijit.ToolbarSeparator;
+	export = x;
 }
 
 declare module 'dijit/form/Select' {

--- a/dijit/1.11/modules.d.ts
+++ b/dijit/1.11/modules.d.ts
@@ -204,3 +204,18 @@ declare module 'dijit/layout/TabController' {
 	const TabController: dijit.layout.TabControllerConstructor;
 	export = TabController;
 }
+
+declare module 'dijit/TitlePane' {
+    const TitlePane: dijit.TitlePaneConstructor;
+    export = TitlePane;
+}
+
+declare module 'dijit/ToolbarSeparator' {
+    const x: dijit.ToolbarSeparator;
+    export = x;
+}
+
+declare module 'dijit/form/Select' {
+	const Button: dijit.form.ButtonConstructor;
+	export = Button;
+}

--- a/dojo/1.11/_base.d.ts
+++ b/dojo/1.11/_base.d.ts
@@ -1275,7 +1275,7 @@ declare namespace dojo {
 			/**
 			 * Copies/adds all properties of one or more sources to dest; returns dest.
 			 */
-			_mixin<T, U>(dest: T, source: U, copyFunc?: (s: any) => any): T & U;
+			mixin<T, U>(dest: T, source: U, copyFunc?: (s: any) => any): T & U;
 
 			/**
 			 * Set a property from a dot-separated string, such as "A.B.C"
@@ -1876,6 +1876,7 @@ declare namespace dojo {
 		onchange(method: string, objOrFunc: EventListener | string): this;
 		onchange(method: string, objOrFunc: Object, funcName: string): this;
 
+		onclick(objOrFunc: EventListener | string): this;
 		onclick(method: string, objOrFunc: EventListener | string): this;
 		onclick(method: string, objOrFunc: Object, funcName: string): this;
 

--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -402,7 +402,7 @@ declare namespace dojo {
 	}
 
 	interface Require {
-		(config: GenericObject, dependencies: string[], callback?: GenericFunction<void>): Require;
+		(config: GenericObject, dependencies?: string[], callback?: GenericFunction<void>): Require;
 		(dependencies: string[], callback: GenericFunction<void>): Require;
 		async: number| boolean;
 		has: dojo.Has;
@@ -1983,7 +1983,7 @@ declare namespace dojo {
 		 * the first will be passed to the subscribers, so any number of arguments
 		 * can be provided (not just event).
 		 */
-		publish(topic: string | ExtensionEvent, event: any): boolean;
+		publish(topic: string | ExtensionEvent, ...event: any[]): boolean;
 
 		/**
 		 * Subscribes to a topic on the pub/sub hub

--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -1874,6 +1874,10 @@ declare namespace dojo {
 		unwatch(): void;
 	}
 
+    interface StatefulConstructor {
+        new<T>(options?: T): T & Stateful;
+    }
+
 	interface Stateful {
 		/**
 		 * Used across all instances a hash to cache attribute names and their getter

--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -1,5 +1,5 @@
 /// <reference path="index.d.ts" />
-/// <reference path="../../doh/1.11/doh" />
+/// <reference path="../../doh/1.11/doh.d.ts" />
 
 declare namespace dojo {
 	/* general implied types */
@@ -1874,9 +1874,9 @@ declare namespace dojo {
 		unwatch(): void;
 	}
 
-    interface StatefulConstructor {
-        new<T>(options?: T): T & Stateful;
-    }
+	interface StatefulConstructor {
+		new<T>(options?: T): T & Stateful;
+	}
 
 	interface Stateful {
 		/**

--- a/dojo/1.11/modules.d.ts
+++ b/dojo/1.11/modules.d.ts
@@ -731,3 +731,8 @@ declare module 'dojo/window' {
 	const window: dojo.WindowModule;
 	export = window;
 }
+
+declare module 'dojo/Stateful' {
+    const stateful: dojo.StatefulConstructor;
+    export = stateful;
+}

--- a/dojo/1.11/modules.d.ts
+++ b/dojo/1.11/modules.d.ts
@@ -733,12 +733,12 @@ declare module 'dojo/window' {
 }
 
 declare module 'dojo/Stateful' {
-    const stateful: dojo.StatefulConstructor;
-    export = stateful;
+	const stateful: dojo.StatefulConstructor;
+	export = stateful;
 }
 
-declare module "dojo/store/Observable" {
-    const observable: dojo.store.ObservableConstructor;
-    export = observable;
+declare module 'dojo/store/Observable' {
+	const observable: dojo.store.ObservableConstructor;
+	export = observable;
 }
 

--- a/dojo/1.11/modules.d.ts
+++ b/dojo/1.11/modules.d.ts
@@ -736,3 +736,9 @@ declare module 'dojo/Stateful' {
     const stateful: dojo.StatefulConstructor;
     export = stateful;
 }
+
+declare module "dojo/store/Observable" {
+    const observable: dojo.store.ObservableConstructor;
+    export = observable;
+}
+

--- a/dojo/1.11/store.d.ts
+++ b/dojo/1.11/store.d.ts
@@ -1,23 +1,23 @@
 declare namespace dojo {
-	namespace store {
-		namespace api {
+    namespace store {
+        namespace api {
 
-			/* dojo/store/api/Store */
+            /* dojo/store/api/Store */
 
-			interface SortInformation {
+            interface SortInformation {
 
 				/**
 				 * The name of the attribute to sort on.
 				 */
-				attribute: string;
+                attribute: string;
 
 				/**
 				 * The direction of the sort.  Default is false.
 				 */
-				descending?: boolean;
-			}
+                descending?: boolean;
+            }
 
-			interface QueryOptions {
+            interface QueryOptions {
 				/**
 				 * A list of attributes to sort on, as well as direction
 				 * For example:
@@ -25,36 +25,36 @@ declare namespace dojo {
 				 * If the sort parameter is omitted, then the natural order of the store may be
 				 * applied if there is a natural order.
 				 */
-				sort?: SortInformation[];
+                sort?: SortInformation[];
 
 				/**
 				 * The first result to begin iteration on
 				 */
-				start?: number;
+                start?: number;
 
 				/**
 				 * The number of how many results should be returned.
 				 */
-				count?: number;
-			}
+                count?: number;
+            }
 
-			interface QueryEngineFunction<T extends Object> {
-				(array: T[]): T[];
-				matches(object: T): boolean;
-			}
+            interface QueryEngineFunction<T extends Object> {
+                (array: T[]): T[];
+                matches(object: T): boolean;
+            }
 
-			type BaseQueryType = string | Object | Function;
+            type BaseQueryType = string | Object | Function;
 
-			interface QueryEngine<T extends Object, Q extends BaseQueryType> {
-				<O extends QueryOptions>(query: Q, options?: O): QueryEngineFunction<T>;
-			}
+            interface QueryEngine<T extends Object, Q extends BaseQueryType> {
+                <O extends QueryOptions>(query: Q, options?: O): QueryEngineFunction<T>;
+            }
 
-			interface PutDirectives<T extends Object> {
+            interface PutDirectives<T extends Object> {
 
 				/**
 				 * Indicates the identity of the object if a new object is created
 				 */
-				id?: string | number;
+                id?: string | number;
 
 				/**
 				 * If the collection of objects in the store has a natural ordering,
@@ -62,13 +62,13 @@ declare namespace dojo {
 				 * object specified by the value of this property. A value of null indicates that the
 				 * object should be last.
 				 */
-				before?: T;
+                before?: T;
 
 				/**
 				 * If the store is hierarchical (with single parenting) this property indicates the
 				 * new parent of the created or updated object.
 				 */
-				parent?: T;
+                parent?: T;
 
 				/**
 				 * If this is provided as a boolean it indicates that the object should or should not
@@ -78,10 +78,10 @@ declare namespace dojo {
 				 * object should be created (which is the same as an add() operation). When
 				 * this property is not provided, either an update or creation is acceptable.
 				 */
-				overwrite?: boolean;
-			}
+                overwrite?: boolean;
+            }
 
-			interface QueryResults<T extends Object> extends ArrayLike<T> {
+            interface QueryResults<T extends Object> extends ArrayLike<T> {
                 sort(sort: Function): QueryResults<T>;
 				/**
 				 * Iterates over the query results, based on
@@ -89,7 +89,7 @@ declare namespace dojo {
 				 * Note that this may executed asynchronously. The callback may be called
 				 * after this function returns.
 				 */
-				forEach(callback: (item: T, id: string | number, results: this) => void, thisObject?: Object): void | this;
+                forEach(callback: (item: T, id: string | number, results: this) => void, thisObject?: Object): void | this;
 
 				/**
 				 * Filters the query results, based on
@@ -97,7 +97,7 @@ declare namespace dojo {
 				 * Note that this may executed asynchronously. The callback may be called
 				 * after this function returns.
 				 */
-				filter(callback: (item: T, id: string | number, results: this) => boolean, thisObject?: Object): this;
+                filter(callback: (item: T, id: string | number, results: this) => boolean, thisObject?: Object): this;
 
 				/**
 				 * Maps the query results, based on
@@ -105,44 +105,44 @@ declare namespace dojo {
 				 * Note that this may executed asynchronously. The callback may be called
 				 * after this function returns.
 				 */
-				map<U>(callback: (item: T, id: string | number, results: this) => U, thisObject?: Object): QueryResults<U>;
+                map<U>(callback: (item: T, id: string | number, results: this) => U, thisObject?: Object): QueryResults<U>;
 
 				/**
 				 * This registers a callback for when the query is complete, if the query is asynchronous.
 				 * This is an optional method, and may not be present for synchronous queries.
 				 */
-				then?: <U>(callback?: promise.PromiseCallback<this, U>, errback?: promise.PromiseErrback, progback?: promise.PromiseProgback) => promise.Promise<U>;
+                then?: <U>(callback?: promise.PromiseCallback<this, U>, errback?: promise.PromiseErrback, progback?: promise.PromiseProgback) => promise.Promise<U>;
 
 				/**
 				 * This registers a callback for notification of when data is modified in the query results.
 				 * This is an optional method, and is usually provided by dojo/store/Observable.
 				 */
-				total: number | promise.Promise<number>;
-			}
+                total: number | promise.Promise<number>;
+            }
 
-			interface Transaction {
+            interface Transaction {
 				/**
 				 * Commits the transaction. This may throw an error if it fails. Of if the operation
 				 * is asynchronous, it may return a promise that represents the eventual success
 				 * or failure of the commit.
 				 */
-				commit(): void;
+                commit(): void;
 
 				/**
 				 * Aborts the transaction. This may throw an error if it fails. Of if the operation
 				 * is asynchronous, it may return a promise that represents the eventual success
 				 * or failure of the abort.
 				 */
-				abort(): void;
-			}
+                abort(): void;
+            }
 
-			interface Store<T extends Object, Q extends BaseQueryType, O extends QueryOptions>{
+            interface Store<T extends Object, Q extends BaseQueryType, O extends QueryOptions> {
 
 				/**
 				 * If the store has a single primary key, this indicates the property to use as the
 				 * identity property. The values of this property should be unique.
 				 */
-				idProperty: string;
+                idProperty: string;
 
 				/**
 				 * If the store can be queried locally (on the client side in JS), this defines
@@ -157,38 +157,38 @@ declare namespace dojo {
 				 * | query.matches({id:"some-object", foo:"bar"}) -> true
 				 * | query.matches({id:"some-object", foo:"something else"}) -> false
 				 */
-				queryEngine: QueryEngine<any, any>;
+                queryEngine: QueryEngine<any, any>;
 
 				/**
 				 * Retrieves an object by its identity
 				 */
-				get(id: string | number): T;
+                get(id: string | number): T;
 
 				/**
 				 * Returns an object's identity
 				 */
-				getIdentity(object: T): string | number;
+                getIdentity(object: T): string | number;
 
 				/**
 				 * Stores an object
 				 */
-				put<D extends PutDirectives<T>>(object: T, directives?: D): string | number;
+                put<D extends PutDirectives<T>>(object: T, directives?: D): string | number;
 
 				/**
 				 * Creates an object, throws an error if the object already exists
 				 */
-				add<D extends PutDirectives<T>>(object: T, directives?: D): string | number;
+                add<D extends PutDirectives<T>>(object: T, directives?: D): string | number;
 
 				/**
 				 * Deletes an object by its identity
 				 */
-				remove(id: string | number): void;
+                remove(id: string | number): void;
 
 				/**
 				 * Queries the store for objects. This does not alter the store, but returns a
 				 * set of data from the store.
 				 */
-				query(query: Q, options?: O): QueryResults<T>;
+                query(query: Q, options?: O): QueryResults<T>;
 
 				/**
 				 * Starts a new transaction.
@@ -196,73 +196,87 @@ declare namespace dojo {
 				 * delete, etc. in which case these operations effectively could be thought of
 				 * as "auto-commit" style actions.
 				 */
-				transaction(): Transaction;
+                transaction(): Transaction;
 
 				/**
 				 * Retrieves the children of an object.
 				 */
-				getChildren(parent: T, options?: O): QueryResults<T>;
+                getChildren(parent: T, options?: O): QueryResults<T>;
 
 				/**
 				 * Returns any metadata about the object. This may include attribution,
 				 * cache directives, history, or version information.
 				 */
-				getMetadata(object: T): Object;
-			}
+                getMetadata(object: T): Object;
+            }
 
-			interface StoreConstructor {
-				new <T extends Object, Q extends BaseQueryType, O extends QueryOptions>(): Store<T, Q, O>;
-			}
-		}
+            interface StoreConstructor {
+                new <T extends Object, Q extends BaseQueryType, O extends QueryOptions>(): Store<T, Q, O>;
+            }
+        }
 
-		namespace util {
+        namespace util {
 
-			/* dojo/store/util/QueryResults */
+            /* dojo/store/util/QueryResults */
 
-			interface QueryResultsFunction {
+            interface QueryResultsFunction {
 				/**
 				 * A function that wraps the results of a store query with additional
 				 * methods.
 				 */
-				<T extends Object>(results: T[]): api.QueryResults<T>;
-			}
+                <T extends Object>(results: T[]): api.QueryResults<T>;
+            }
 
-			/* dojo/store/util/SimpleQueryEngine */
-			interface SimpleQueryEngine extends api.QueryEngine<Object, api.BaseQueryType> {}
-		}
+            /* dojo/store/util/SimpleQueryEngine */
+            interface SimpleQueryEngine extends api.QueryEngine<Object, api.BaseQueryType> { }
+        }
 
-		/* dojo/store/Memory */
+        /* dojo/store/Memory */
 
-		interface MemoryOptions<T extends Object> {
-			data?: T[];
-			idProperty?: string;
-			queryEngine?: api.QueryEngine<any, any>;
-			setData?: (data: T[]) => void;
-		}
+        interface MemoryOptions<T extends Object> {
+            data?: T[];
+            idProperty?: string;
+            queryEngine?: api.QueryEngine<any, any>;
+            setData?: (data: T[]) => void;
+        }
 
-		interface Memory<T extends Object> extends api.Store<T, api.BaseQueryType, api.QueryOptions> {
+        interface Memory<T extends Object> extends api.Store<T, api.BaseQueryType, api.QueryOptions> {
 			/**
 			 * The array of all the objects in the memory store
 			 */
-			data: T[];
+            data: T[];
 
 			/**
 			 * An index of data indices into the data array by id
 			 */
-			index: { [id: string]: number };
+            index: { [id: string]: number };
 
 			/**
 			 * Sets the given data as the source for this store, and indexes it
 			 */
-			setData(data: T[]): void;
-		}
+            setData(data: T[]): void;
+        }
 
-		interface MemoryConstructor {
+        interface MemoryConstructor {
 			/**
 			 * This is a basic in-memory object store. It implements dojo/store/api/Store.
 			 */
-			new <T extends Object>(options?: MemoryOptions<T>): Memory<T>;
-		}
+            new <T extends Object>(options?: MemoryOptions<T>): T & Memory<T>;
+        }
 
-	}
+        interface Observable<T> extends dojo.Stateful {
+            observe(cb: Function): any;
+            query(filter?: any): (T & Observable<T>)[] & { observe: Function };
+            // set(pair: any);
+            // set(name: string, value: any): T;
+            // get(name: string): any;
+        }
+
+        interface ObservableConstructor {
+            new <T>(options?: T): T & Observable<T>;
+        }
+
+
+
+    }
 }

--- a/dojo/1.11/store.d.ts
+++ b/dojo/1.11/store.d.ts
@@ -82,7 +82,7 @@ declare namespace dojo {
 			}
 
 			interface QueryResults<T extends Object> extends ArrayLike<T> {
-
+                sort(sort: Function): QueryResults<T>;
 				/**
 				 * Iterates over the query results, based on
 				 * https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Objects/Array/forEach.

--- a/dojo/1.11/store.d.ts
+++ b/dojo/1.11/store.d.ts
@@ -1,23 +1,23 @@
 declare namespace dojo {
-    namespace store {
-        namespace api {
+	namespace store {
+		namespace api {
 
-            /* dojo/store/api/Store */
+			/* dojo/store/api/Store */
 
-            interface SortInformation {
+			interface SortInformation {
 
 				/**
 				 * The name of the attribute to sort on.
 				 */
-                attribute: string;
+				attribute: string;
 
 				/**
 				 * The direction of the sort.  Default is false.
 				 */
-                descending?: boolean;
-            }
+				descending?: boolean;
+			}
 
-            interface QueryOptions {
+			interface QueryOptions {
 				/**
 				 * A list of attributes to sort on, as well as direction
 				 * For example:
@@ -25,36 +25,36 @@ declare namespace dojo {
 				 * If the sort parameter is omitted, then the natural order of the store may be
 				 * applied if there is a natural order.
 				 */
-                sort?: SortInformation[];
+				sort?: SortInformation[];
 
 				/**
 				 * The first result to begin iteration on
 				 */
-                start?: number;
+				start?: number;
 
 				/**
 				 * The number of how many results should be returned.
 				 */
-                count?: number;
-            }
+				count?: number;
+			}
 
-            interface QueryEngineFunction<T extends Object> {
-                (array: T[]): T[];
-                matches(object: T): boolean;
-            }
+			interface QueryEngineFunction<T extends Object> {
+				(array: T[]): T[];
+				matches(object: T): boolean;
+			}
 
-            type BaseQueryType = string | Object | Function;
+			type BaseQueryType = string | Object | Function;
 
-            interface QueryEngine<T extends Object, Q extends BaseQueryType> {
-                <O extends QueryOptions>(query: Q, options?: O): QueryEngineFunction<T>;
-            }
+			interface QueryEngine<T extends Object, Q extends BaseQueryType> {
+				<O extends QueryOptions>(query: Q, options?: O): QueryEngineFunction<T>;
+			}
 
-            interface PutDirectives<T extends Object> {
+			interface PutDirectives<T extends Object> {
 
 				/**
 				 * Indicates the identity of the object if a new object is created
 				 */
-                id?: string | number;
+				id?: string | number;
 
 				/**
 				 * If the collection of objects in the store has a natural ordering,
@@ -62,13 +62,13 @@ declare namespace dojo {
 				 * object specified by the value of this property. A value of null indicates that the
 				 * object should be last.
 				 */
-                before?: T;
+				before?: T;
 
 				/**
 				 * If the store is hierarchical (with single parenting) this property indicates the
 				 * new parent of the created or updated object.
 				 */
-                parent?: T;
+				parent?: T;
 
 				/**
 				 * If this is provided as a boolean it indicates that the object should or should not
@@ -78,18 +78,18 @@ declare namespace dojo {
 				 * object should be created (which is the same as an add() operation). When
 				 * this property is not provided, either an update or creation is acceptable.
 				 */
-                overwrite?: boolean;
-            }
+				overwrite?: boolean;
+			}
 
-            interface QueryResults<T extends Object> extends ArrayLike<T> {
-                sort(sort: Function): QueryResults<T>;
+			interface QueryResults<T extends Object> extends ArrayLike<T> {
+				sort(sort: Function): QueryResults<T>;
 				/**
 				 * Iterates over the query results, based on
 				 * https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Objects/Array/forEach.
 				 * Note that this may executed asynchronously. The callback may be called
 				 * after this function returns.
 				 */
-                forEach(callback: (item: T, id: string | number, results: this) => void, thisObject?: Object): void | this;
+				forEach(callback: (item: T, id: string | number, results: this) => void, thisObject?: Object): void | this;
 
 				/**
 				 * Filters the query results, based on
@@ -97,7 +97,7 @@ declare namespace dojo {
 				 * Note that this may executed asynchronously. The callback may be called
 				 * after this function returns.
 				 */
-                filter(callback: (item: T, id: string | number, results: this) => boolean, thisObject?: Object): this;
+				filter(callback: (item: T, id: string | number, results: this) => boolean, thisObject?: Object): this;
 
 				/**
 				 * Maps the query results, based on
@@ -105,44 +105,44 @@ declare namespace dojo {
 				 * Note that this may executed asynchronously. The callback may be called
 				 * after this function returns.
 				 */
-                map<U>(callback: (item: T, id: string | number, results: this) => U, thisObject?: Object): QueryResults<U>;
+				map<U>(callback: (item: T, id: string | number, results: this) => U, thisObject?: Object): QueryResults<U>;
 
 				/**
 				 * This registers a callback for when the query is complete, if the query is asynchronous.
 				 * This is an optional method, and may not be present for synchronous queries.
 				 */
-                then?: <U>(callback?: promise.PromiseCallback<this, U>, errback?: promise.PromiseErrback, progback?: promise.PromiseProgback) => promise.Promise<U>;
+				then?: <U>(callback?: promise.PromiseCallback<this, U>, errback?: promise.PromiseErrback, progback?: promise.PromiseProgback) => promise.Promise<U>;
 
 				/**
 				 * This registers a callback for notification of when data is modified in the query results.
 				 * This is an optional method, and is usually provided by dojo/store/Observable.
 				 */
-                total: number | promise.Promise<number>;
-            }
+				total: number | promise.Promise<number>;
+			}
 
-            interface Transaction {
+			interface Transaction {
 				/**
 				 * Commits the transaction. This may throw an error if it fails. Of if the operation
 				 * is asynchronous, it may return a promise that represents the eventual success
 				 * or failure of the commit.
 				 */
-                commit(): void;
+				commit(): void;
 
 				/**
 				 * Aborts the transaction. This may throw an error if it fails. Of if the operation
 				 * is asynchronous, it may return a promise that represents the eventual success
 				 * or failure of the abort.
 				 */
-                abort(): void;
-            }
+				abort(): void;
+			}
 
-            interface Store<T extends Object, Q extends BaseQueryType, O extends QueryOptions> {
+			interface Store<T extends Object, Q extends BaseQueryType, O extends QueryOptions> {
 
 				/**
 				 * If the store has a single primary key, this indicates the property to use as the
 				 * identity property. The values of this property should be unique.
 				 */
-                idProperty: string;
+				idProperty: string;
 
 				/**
 				 * If the store can be queried locally (on the client side in JS), this defines
@@ -157,38 +157,38 @@ declare namespace dojo {
 				 * | query.matches({id:"some-object", foo:"bar"}) -> true
 				 * | query.matches({id:"some-object", foo:"something else"}) -> false
 				 */
-                queryEngine: QueryEngine<any, any>;
+				queryEngine: QueryEngine<any, any>;
 
 				/**
 				 * Retrieves an object by its identity
 				 */
-                get(id: string | number): T;
+				get(id: string | number): T;
 
 				/**
 				 * Returns an object's identity
 				 */
-                getIdentity(object: T): string | number;
+				getIdentity(object: T): string | number;
 
 				/**
 				 * Stores an object
 				 */
-                put<D extends PutDirectives<T>>(object: T, directives?: D): string | number;
+				put<D extends PutDirectives<T>>(object: T, directives?: D): string | number;
 
 				/**
 				 * Creates an object, throws an error if the object already exists
 				 */
-                add<D extends PutDirectives<T>>(object: T, directives?: D): string | number;
+				add<D extends PutDirectives<T>>(object: T, directives?: D): string | number;
 
 				/**
 				 * Deletes an object by its identity
 				 */
-                remove(id: string | number): void;
+				remove(id: string | number): void;
 
 				/**
 				 * Queries the store for objects. This does not alter the store, but returns a
 				 * set of data from the store.
 				 */
-                query(query: Q, options?: O): QueryResults<T>;
+				query(query: Q, options?: O): QueryResults<T>;
 
 				/**
 				 * Starts a new transaction.
@@ -196,87 +196,85 @@ declare namespace dojo {
 				 * delete, etc. in which case these operations effectively could be thought of
 				 * as "auto-commit" style actions.
 				 */
-                transaction(): Transaction;
+				transaction(): Transaction;
 
 				/**
 				 * Retrieves the children of an object.
 				 */
-                getChildren(parent: T, options?: O): QueryResults<T>;
+				getChildren(parent: T, options?: O): QueryResults<T>;
 
 				/**
 				 * Returns any metadata about the object. This may include attribution,
 				 * cache directives, history, or version information.
 				 */
-                getMetadata(object: T): Object;
-            }
+				getMetadata(object: T): Object;
+			}
 
-            interface StoreConstructor {
-                new <T extends Object, Q extends BaseQueryType, O extends QueryOptions>(): Store<T, Q, O>;
-            }
-        }
+			interface StoreConstructor {
+				new <T extends Object, Q extends BaseQueryType, O extends QueryOptions>(): Store<T, Q, O>;
+			}
+		}
 
-        namespace util {
+		namespace util {
 
-            /* dojo/store/util/QueryResults */
+			/* dojo/store/util/QueryResults */
 
-            interface QueryResultsFunction {
+			interface QueryResultsFunction {
 				/**
 				 * A function that wraps the results of a store query with additional
 				 * methods.
 				 */
-                <T extends Object>(results: T[]): api.QueryResults<T>;
-            }
+				<T extends Object>(results: T[]): api.QueryResults<T>;
+			}
 
-            /* dojo/store/util/SimpleQueryEngine */
-            interface SimpleQueryEngine extends api.QueryEngine<Object, api.BaseQueryType> { }
-        }
+			/* dojo/store/util/SimpleQueryEngine */
+			interface SimpleQueryEngine extends api.QueryEngine<Object, api.BaseQueryType> { }
+		}
 
-        /* dojo/store/Memory */
+		/* dojo/store/Memory */
 
-        interface MemoryOptions<T extends Object> {
-            data?: T[];
-            idProperty?: string;
-            queryEngine?: api.QueryEngine<any, any>;
-            setData?: (data: T[]) => void;
-        }
+		interface MemoryOptions<T extends Object> {
+			data?: T[];
+			idProperty?: string;
+			queryEngine?: api.QueryEngine<any, any>;
+			setData?: (data: T[]) => void;
+		}
 
-        interface Memory<T extends Object> extends api.Store<T, api.BaseQueryType, api.QueryOptions> {
+		interface Memory<T extends Object> extends api.Store<T, api.BaseQueryType, api.QueryOptions> {
 			/**
 			 * The array of all the objects in the memory store
 			 */
-            data: T[];
+			data: T[];
 
 			/**
 			 * An index of data indices into the data array by id
 			 */
-            index: { [id: string]: number };
+			index: { [id: string]: number };
 
 			/**
 			 * Sets the given data as the source for this store, and indexes it
 			 */
-            setData(data: T[]): void;
-        }
+			setData(data: T[]): void;
+		}
 
-        interface MemoryConstructor {
+		interface MemoryConstructor {
 			/**
 			 * This is a basic in-memory object store. It implements dojo/store/api/Store.
 			 */
-            new <T extends Object>(options?: MemoryOptions<T>): T & Memory<T>;
-        }
+			new <T extends Object>(options?: MemoryOptions<T>): T & Memory<T>;
+		}
 
-        interface Observable<T> extends dojo.Stateful {
-            observe(cb: Function): any;
-            query(filter?: any): (T & Observable<T>)[] & { observe: Function };
-            // set(pair: any);
-            // set(name: string, value: any): T;
-            // get(name: string): any;
-        }
+		interface Observable<T> extends dojo.Stateful {
+			observe(cb: Function): any;
+			query(filter?: any): (T & Observable<T>)[] & { observe: Function };
+			// set(pair: any);
+			// set(name: string, value: any): T;
+			// get(name: string): any;
+		}
 
-        interface ObservableConstructor {
-            new <T>(options?: T): T & Observable<T>;
-        }
+		interface ObservableConstructor {
+			new <T>(options?: T): T & Observable<T>;
+		}
 
-
-
-    }
+	}
 }


### PR DESCRIPTION
1. lang._mixin -> lang.mixin (Possible typo or I'm missed a memo?)
2. Existing code uses query.onclick(callback) but typings complained
3. topic.publish(topic) is valid but was saying a second param was required.
4. require({configuration}) is valid, yes?  I've been doing it for years now so I hope so!
