### PR TITLE
fix dojo.date.Date namespace hiding global Date, fixes #18

### DIFF
--- a/dojo/1.11/date.d.ts
+++ b/dojo/1.11/date.d.ts
@@ -7,7 +7,7 @@ declare namespace dojo {
 		/* type DatePortion = 'date' | 'time' | 'datetime'; */
 		/* type DateInterval = 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second' | 'millisecond' | 'quarter' | 'week' | 'weekday'; */
 
-		interface Date {
+		interface DateBase {
 			/**
 			 * Returns the number of days in the month used by dateObject
 			 */
@@ -32,14 +32,14 @@ declare namespace dojo {
 			/**
 			 * Add to a Date in intervals of different size, from milliseconds to years
 			 */
-			add(date: Date, interval: string /* DateInternval */, amount: number): Date;
+			add(date: Date, interval: string /* DateInterval */, amount: number): Date;
 
 			/**
 			 * Get the difference in a specific unit of time (e.g., number of
 			 * months, weeks, days, etc.) between two dates, rounded to the
 			 * nearest integer.
 			 */
-			difference(date1: Date, date2?: Date, internval?: string /* DateInternval */): number;
+			difference(date1: Date, date2?: Date, interval?: string /* DateInterval */): number;
 		}
 
 		/* dojo/date/locale */

--- a/dojo/1.11/modules.d.ts
+++ b/dojo/1.11/modules.d.ts
@@ -225,7 +225,7 @@ declare module 'dojo/data/ObjectStore' {
 }
 
 declare module 'dojo/date' {
-	const date: dojo.date.Date;
+	const date: dojo.date.DateBase;
 	export = date;
 }
 


### PR DESCRIPTION
Also fixed misspelling of "interval" in date.d.ts.
