### PR TITLE
Update Promise.all to take Thenables

### DIFF
--- a/dojo/1.11/promise.d.ts
+++ b/dojo/1.11/promise.d.ts
@@ -15,10 +15,10 @@ declare namespace dojo {
 			 * 						keys). If passed neither an object or array it is resolved with an
 			 * 						undefined value.
 			 */
-			<T>(array: Promise<T>[]): Promise<T[]>;
-			<T>(object: { [name: string]: Promise<T> }): Promise<{ [name: string]: T }>;
-			(array: Promise<any>[]): Promise<any[]>;
-			(object: { [name: string]: Promise<any> }): Promise<{ [name: string]: any }>;
+			<T>(array: Thenable<T>[]): Promise<T[]>;
+			<T>(object: { [name: string]: Thenable<T> }): Promise<{ [name: string]: T }>;
+			(array: Thenable<any>[]): Promise<any[]>;
+			(object: { [name: string]: Thenable<any> }): Promise<{ [name: string]: any }>;
 		}
 
 		/* dojo/promise/first */


### PR DESCRIPTION
This change allows for other Promise signatures to be passed to `all` which is supported by `dojo/when` used by `dojo/promise/all`.
