### PR TITLE
Type PromiseErrBack return value types in promise chain

### DIFF
--- a/dojo/1.11/_base.d.ts
+++ b/dojo/1.11/_base.d.ts
@@ -599,12 +599,12 @@ declare namespace dojo {
 			/**
 			 * Adds callback and error callback for this deferred instance.
 			 */
-			addCallbacks<U>(callback?: promise.PromiseCallback<T, U>, errback?: promise.PromiseErrback): Deferred<U>;
+			addCallbacks<U>(callback?: promise.PromiseCallback<T, U>, errback?: promise.PromiseErrback<U>): Deferred<U>;
 
 			/**
 			 * Add new callbacks to the deferred.
 			 */
-			then<U>(callback?: promise.PromiseCallback<T, U>, errback?: promise.PromiseErrback, progback?: promise.PromiseProgback): promise.Promise<U>;
+			then<U>(callback?: promise.PromiseCallback<T, U>, errback?: promise.PromiseErrback<U>, progback?: promise.PromiseProgback): promise.Promise<U>;
 
 			/**
 			 * Cancels the asynchronous operation
@@ -619,12 +619,12 @@ declare namespace dojo {
 			/**
 			 * Adds error callback for this deferred instance.
 			 */
-			addErrback(errback: promise.PromiseErrback): Deferred<T>;
+			addErrback<U>(errback: promise.PromiseErrback<U>): Deferred<U>;
 
 			/**
 			 * Add handler as both successful callback and error callback for this deferred instance.
 			 */
-			addBoth(callback?: promise.PromiseErrback): Deferred<T>;
+			addBoth<U>(callback?: promise.PromiseErrback<U>): Deferred<U>;
 
 			fired: number;
 		}
@@ -642,7 +642,7 @@ declare namespace dojo {
 			 * Transparently applies callbacks to values and/or promises.
 			 */
 			when<T>(valueOrPromise: any): dojo.Deferred<T>;
-			when<T, U>(valueOrPromise: any, callback?: promise.PromiseCallback<T, U>, errback?: promise.PromiseErrback, progback?: promise.PromiseProgback): dojo.Deferred<U>;
+			when<T, U>(valueOrPromise: any, callback?: promise.PromiseCallback<T, U>, errback?: promise.PromiseErrback<U>, progback?: promise.PromiseProgback): dojo.Deferred<U>;
 		}
 
 		/* dojo/_base/event */

--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -351,7 +351,7 @@ declare namespace dojo {
 		/**
 		 * Add new callbacks to the deferred.
 		 */
-		then<U>(callback?: promise.PromiseCallback<T, U>, errback?: promise.PromiseErrback, progback?: promise.PromiseProgback): promise.Promise<U>;
+		then<U>(callback?: promise.PromiseCallback<T, U>, errback?: promise.PromiseErrback<U>, progback?: promise.PromiseProgback): promise.Promise<U>;
 
 		/**
 		 * Inform the deferred it may cancel its asynchronous operation.
@@ -2019,11 +2019,11 @@ declare namespace dojo {
 		<T>(value: T | dojo.promise.Promise<T>): dojo.promise.Promise<T>;
 		<T>(value: T | dojo.promise.Promise<T>,
 			callback?: dojo.promise.PromiseCallback<T, T>,
-			errback?: dojo.promise.PromiseErrback,
+			errback?: dojo.promise.PromiseErrback<T>,
 			progress?: dojo.promise.PromiseProgback): T | dojo.promise.Promise<T>;
 		<T, U>(value: T | dojo.promise.Promise<T>,
 			callback?: dojo.promise.PromiseCallback<T, U>,
-			errback?: dojo.promise.PromiseErrback,
+			errback?: dojo.promise.PromiseErrback<U>,
 			progress?: dojo.promise.PromiseProgback): U | dojo.promise.Promise<U>;
 	}
 

--- a/dojo/1.11/promise.d.ts
+++ b/dojo/1.11/promise.d.ts
@@ -49,15 +49,15 @@ declare namespace dojo {
 			/**
 			 * Add new callbacks to the promise.
 			 */
-			then<U>(callback?: PromiseCallback<T, U>, errback?: PromiseErrback, progback?: PromiseProgback): Promise<U>;
+			then<U>(callback?: PromiseCallback<T, U>, errback?: PromiseErrback<U>, progback?: PromiseProgback): Promise<U>;
 		}
 
 		interface PromiseCallback<T, U> {
 			(result: T): U | Thenable<U>;
 		}
 
-		interface PromiseErrback {
-			(error: any): void;
+		interface PromiseErrback<U> {
+			(error: any): U | Thenable<U> | void;
 		}
 
 		interface PromiseProgback {
@@ -94,12 +94,12 @@ declare namespace dojo {
 			 * Add a callback to be invoked when the promise is resolved
 			 * or rejected.
 			 */
-			always<U>(callbackOrErrback: PromiseCallback<T, U> | PromiseErrback): Promise<U>;
+			always<U>(callbackOrErrback: PromiseCallback<T, U> | PromiseErrback<U>): Promise<U>;
 
 			/**
 			 * Add new errbacks to the promise.
 			 */
-			otherwise(errback: PromiseErrback): Promise<T>;
+			otherwise<U>(errback: PromiseErrback<U>): Promise<U>;
 
 			trace(): this;
 			traceRejected(): this;

--- a/dojo/1.11/store.d.ts
+++ b/dojo/1.11/store.d.ts
@@ -111,7 +111,7 @@ declare namespace dojo {
 				 * This registers a callback for when the query is complete, if the query is asynchronous.
 				 * This is an optional method, and may not be present for synchronous queries.
 				 */
-				then?: <U>(callback?: promise.PromiseCallback<this, U>, errback?: promise.PromiseErrback, progback?: promise.PromiseProgback) => promise.Promise<U>;
+				then?: <U>(callback?: promise.PromiseCallback<this, U>, errback?: promise.PromiseErrback<U>, progback?: promise.PromiseProgback) => promise.Promise<U>;
 
 				/**
 				 * This registers a callback for notification of when data is modified in the query results.


### PR DESCRIPTION
The error handlers (such as `.otherwise`) may return a value that gets passed down in the chain, in the same way as a `PromiseCallback` does. For example, given the following sample chain:

``` ts
const promise = new Deferred<string>().promise;

promise
    .otherwise(() => 5)
    .then(n => n.toFixed());
```

Before PR:

```
`test.ts(12,16): error TS2339: Property 'toFixed' does not exist on type 'string'.`
```

After PR, compiles correctly.
