### PR TITLE
Update dojo/dom#byId signature to accept 'id' as Element.

### DIFF
--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -447,7 +447,7 @@ declare namespace dojo {
 		 * Returns DOM node with matching `id` attribute or falsy value (ex: null or undefined)
 		 * if not found. Internally if `id` is not a string then `id` returned.
 		 */
-		byId<E extends Element>(id: string, doc?: Document): E;
+		byId<E extends Element>(id: string | E, doc?: Document): E;
 
 		/**
 		 * Returns true if node is a descendant of ancestor


### PR DESCRIPTION
The [API](http://dojotoolkit.org/api/?qs=1.10/dojo/dom) and [reference](http://dojotoolkit.org/reference-guide/1.10/dojo/dom.html) docs state that `id` can be a DOM Node. 

Should the JSDoc be updated to: 

``` js
/**
 * Returns DOM node with matching `id` attribute or falsy value (ex: null or undefined)
 * if not found. If `id` is a DomNode, then `id` is returned.
 */
```

?
