### PR TITLE
Remove superfluous typings remaps

### DIFF
--- a/custom/dojo2-extras/immutable.d.ts
+++ b/custom/dojo2-extras/immutable.d.ts
@@ -1,8 +1,0 @@
-/**
- * These provide re-exports of various modules that align to the typical
- * configuration of a Dojo 2 application
- */
-
-declare module 'immutable/immutable' {
-	export * from 'immutable';
-}

--- a/custom/dojo2-extras/maquette.d.ts
+++ b/custom/dojo2-extras/maquette.d.ts
@@ -1,8 +1,0 @@
-/**
- * These provide re-exports of various modules that align to the typical
- * configuration of a Dojo 2 application
- */
-
-declare module 'maquette/maquette' {
-	export * from 'maquette';
-}


### PR DESCRIPTION
These should be mapped in the loader instead.

Example:
https://github.com/dojo/widgets/blob/2ec9eb5b3f600a70184ad71281f7d7e7cb798107/tests/intern.ts#L68
