### PR TITLE
Add typings for the intern test interface files 

### DIFF
--- a/custom/intern/intern.d.ts
+++ b/custom/intern/intern.d.ts
@@ -85,6 +85,21 @@ declare module 'intern!tdd' {
 	export = tdd;
 }
 
+declare module 'intern/lib/interfaces/bdd' {
+	import * as bdd from 'intern!bdd';
+	export = bdd;
+}
+
+declare module 'intern/lib/interfaces/object' {
+	import * as object from 'intern!object';
+	export = object;
+}
+
+declare module 'intern/lib/interfaces/tdd' {
+	import * as tdd from 'intern!tdd';
+	export = tdd;
+}
+
 declare module 'intern/chai!' {
 	const chai: Chai.ChaiStatic;
 	export = chai;


### PR DESCRIPTION
We currently have typings for the shortcut AMD plugin syntax ie `intern!tdd`, but not for the files at the physical location ie `intern/lib/interfaces/tdd`

The typings should perhaps be aliased the other way around to match what happens in the implementation, but it makes no difference in practice.
