### PR TITLE
Update dojo/on#emit signature.

### DIFF
--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -784,7 +784,7 @@ declare namespace dojo {
 
 	interface Evented {
 		on(type: string | ExtensionEvent, listener: EventListener): Handle;
-		emit(type: string | ExtensionEvent, event?: any): boolean;
+		emit(type: string | ExtensionEvent, event: any): boolean;
 	}
 
 	interface EventedConstructor extends _base.DeclareConstructor<Evented> {


### PR DESCRIPTION
According to the [doc](https://dojotoolkit.org/reference-guide/1.10/dojo/on.html#emit) and [implementation](https://github.com/dojo/dojo/blob/master/on.js#L376), `event` is not optional.

