### PR TITLE
Update dojox/gfx/matrix#scaleAt signature.

### DIFF
--- a/dojox/1.11/gfx/matrix.d.ts
+++ b/dojox/1.11/gfx/matrix.d.ts
@@ -50,9 +50,9 @@ declare namespace dojox {
 			}
 
 			interface ScaleAt {
-				(factor: dojox.gfx.Point, point: dojox.gfx.Point): Matrix2D;
 				(factor: number | dojox.gfx.Point, point: dojox.gfx.Point): Matrix2D;
 				(factor: number | dojox.gfx.Point, x: number, y: number): Matrix2D;
+				(factorX: number, factorY: number, point: dojox.gfx.Point): Matrix2D;
 				(factorX: number, factorY: number, x: number, y: number): Matrix2D;
 			}
 


### PR DESCRIPTION
Added missing signature and removed redundant one.

Reference doc: https://dojotoolkit.org/reference-guide/1.10/dojox/gfx-geometric-properties.html#scaleat:

> scaleAt(a, b, p)

Where `a` and `b` are numbers and `p` is a 2D coordinate

