### PR TITLE
Add module path for dijit/Destroyable

### DIFF
--- a/dijit/1.11/modules.d.ts
+++ b/dijit/1.11/modules.d.ts
@@ -36,6 +36,12 @@ declare module 'dijit/CalendarLite' {
 	export = CalendarLite;
 }
 
+declare module 'dijit/Destroyable' {
+	type Destroyable = dijit.Destroyable;
+	const Destroyable: dijit.DestroyableConstructor;
+	export = Destroyable;
+}
+
 declare module 'dijit/Dialog' {
 	type Dialog = dijit.Dialog;
 	const Dialog: dijit.DialogConstructor;


### PR DESCRIPTION
Destroyable is missing from the list of modules. When the module definition is not present, the compiler throws an error when I try to declare a new class that mixes in Destroyable.