### PR TITLE
Add definition for dojo/_base/browser

### DIFF
--- a/dojo/1.11/modules.d.ts
+++ b/dojo/1.11/modules.d.ts
@@ -5,6 +5,11 @@ declare module 'dojo/_base/array' {
 	export = dojoArray;
 }
 
+declare module 'dojo/_base/browser' {
+	const ready: dojo.Ready;
+	export = ready;
+}
+
 declare module 'dojo/_base/Color' {
 	type Color = dojo._base.Color;
 	const Color: dojo._base.ColorConstructor;


### PR DESCRIPTION
Looking at the source here [_base/browser.js](https://github.com/dojo/dojo/blob/master/_base/browser.js) it appears that `dojo/ready` is imported and then returned as the content of the module.