### PR TITLE
Add 'new' to Observable interface to make it a constructor function

### DIFF
--- a/dojo/1.11/store.d.ts
+++ b/dojo/1.11/store.d.ts
@@ -464,7 +464,7 @@ declare namespace dojo {
 		}
 
 		interface Observable {
-			<T, Q extends api.BaseQueryType, O extends api.QueryOptions, S extends api.Store<T, Q, O>>(store: S): ObservableMixin<T, Q, O> & S;
+			new <T, Q extends api.BaseQueryType, O extends api.QueryOptions, S extends api.Store<T, Q, O>>(store: S): ObservableMixin<T, Q, O> & S;
 		}
 
 	}


### PR DESCRIPTION
Observable is a constructor function, but without the `new` keyword I can not create instances of it without getting the following error:

```
error TS2350: Only a void function can be called with the 'new' keyword.
```