### PR TITLE
lang.hitch will return the first argument if no second argument is given

### DIFF
--- a/dojo/1.11/_base.d.ts
+++ b/dojo/1.11/_base.d.ts
@@ -1354,6 +1354,8 @@ declare namespace dojo {
 			 * Each of these values will be used to "placehold" (similar to curry)
 			 * for the hitched function.
 			 */
+			hitch(method: string): Function;
+			hitch<T extends Function>(method: T): T;
 			hitch<T extends Function>(scope: any, method: T): T;
 			hitch<T extends Function>(scope: any, method: string | Function, ...args: any[]): T;
 


### PR DESCRIPTION
According to the implementation for `lang.hitch`, when no second argument is given, the first argument is returned if it is not a string. If the first argument is a string, it will try to find that method name on `dojo.global`.

https://github.com/dojo/dojo/blob/master/_base/lang.js#L376