### PR TITLE
Augment the signature of dojo._base.declare

### DIFF
--- a/dojo/1.11/_base.d.ts
+++ b/dojo/1.11/_base.d.ts
@@ -536,14 +536,30 @@ declare namespace dojo {
 		 * Create a feature-rich constructor from compact notation.
 		 */
 		interface Declare {
-			<A, B, C>(className: string, superClass: [DeclareConstructor<A>, DeclareConstructor<B>], props: C): DeclareConstructor<A & B & C>;
+			<A, B, C, D>(superClass: [DeclareConstructor<A>, DeclareConstructor<B>, DeclareConstructor<C>, DeclareConstructor<D>]): DeclareConstructor<A & B & C & D>;
+			<A, B, C>(superClass: [DeclareConstructor<A>, DeclareConstructor<B>, DeclareConstructor<C>]): DeclareConstructor<A & B & C>;
+			<A, B>(superClass: [DeclareConstructor<A>, DeclareConstructor<B>]): DeclareConstructor<A & B>;
+			<A>(superClass: DeclareConstructor<A> | [DeclareConstructor<A>]): DeclareConstructor<A>;
+
+			<A, B, C, D, E>(superClass: [DeclareConstructor<A>, DeclareConstructor<B>, DeclareConstructor<C>, DeclareConstructor<D>], props: E): DeclareConstructor<A & B & C & D & E>;
+			<A, B, C, D>(superClass: [DeclareConstructor<A>, DeclareConstructor<B>, DeclareConstructor<C>], props: D): DeclareConstructor<A & B & C & D>;
 			<A, B, C>(superClass: [DeclareConstructor<A>, DeclareConstructor<B>], props: C): DeclareConstructor<A & B & C>;
-			<A, B>(className: string, superClass: DeclareConstructor<A>, props: B): DeclareConstructor<A & B>;
-			<A, B>(superClass: DeclareConstructor<A>, props: B): DeclareConstructor<A & B>;
-			<A>(className: string, superClass: DeclareConstructor<any> | DeclareConstructor<any>[], props: A): DeclareConstructor<A>;
-			<A>(superClass: DeclareConstructor<any> | DeclareConstructor<any>[], props: A): DeclareConstructor<A>;
-			(className: string, superClass: any | any[], props: any): DeclareConstructor<any>;
-			(superClass: any | any[], props: any): DeclareConstructor<any>;
+			<A, B>(superClass: DeclareConstructor<A> | [DeclareConstructor<A>], props: B): DeclareConstructor<A & B>;
+
+			<A, B, C, D>(className: string, superClass: [DeclareConstructor<A>, DeclareConstructor<B>, DeclareConstructor<C>, DeclareConstructor<D>]): DeclareConstructor<A & B & C & D>;
+			<A, B, C>(className: string, superClass: [DeclareConstructor<A>, DeclareConstructor<B>, DeclareConstructor<C>]): DeclareConstructor<A & B & C>;
+			<A, B>(className: string, superClass: [DeclareConstructor<A>, DeclareConstructor<B>]): DeclareConstructor<A & B>;
+			<A>(className: string, superClass: DeclareConstructor<A> | [DeclareConstructor<A>]): DeclareConstructor<A>;
+
+			<A, B, C, D, E>(className: string, superClass: [DeclareConstructor<A>, DeclareConstructor<B>, DeclareConstructor<C>, DeclareConstructor<D>], props: E): DeclareConstructor<A & B & C & D & E>;
+			<A, B, C, D>(className: string, superClass: [DeclareConstructor<A>, DeclareConstructor<B>, DeclareConstructor<C>], props: D): DeclareConstructor<A & B & C & D>;
+			<A, B, C>(className: string, superClass: [DeclareConstructor<A>, DeclareConstructor<B>], props: C): DeclareConstructor<A & B & C>;
+			<A, B>(className: string, superClass: DeclareConstructor<A> | [DeclareConstructor<A>], props: B): DeclareConstructor<A & B>;
+
+			<A>(className: string, superClass: any, props: A): DeclareConstructor<A>;
+			(className: string, superClass: any): DeclareConstructor<any>;
+			<A>(superClass: any, props: A): DeclareConstructor<A>;
+			(superClass: any): DeclareConstructor<any>;
 
 			/**
 			 * Mix in properties skipping a constructor and decorating functions


### PR DESCRIPTION
Dojo Declare can take up to three parameters, however the only required one is `superClass`. If the `props` parameter is omitted, Declare will use an empty object.

Also, I have grouped the method signatures by the number of parameters rather than interleaving the various declarations. I find this easier to read and comprehend.

I have also extended the type list to allow for four types instead of three. Of course we could keep extending the signature to allow for more, but this seems like enough for now.