### PR TITLE
Update the signature for domStyle.set

### DIFF
--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -759,7 +759,8 @@ declare namespace dojo {
 		/**
 		 * Sets styles on a node.
 		 */
-		set(node: ElementOrString, name: string | DomComputedStyle, value?: string | number): DomComputedStyle;
+		set(node: ElementOrString, name: DomComputedStyle): DomComputedStyle;
+		set(node: ElementOrString, name: string, value: string | number): DomComputedStyle;
 
 		/**
 		 * converts style value to pixels on IE or return a numeric value.

--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -759,7 +759,7 @@ declare namespace dojo {
 		/**
 		 * Sets styles on a node.
 		 */
-		set(node: ElementOrString, name: string | DomComputedStyle, value?: string): DomComputedStyle;
+		set(node: ElementOrString, name: string | DomComputedStyle, value?: string | number): DomComputedStyle;
 
 		/**
 		 * converts style value to pixels on IE or return a numeric value.


### PR DESCRIPTION
Giving a number as value should be a value use case:

```javascript
domStyle.set("my-node", "width", 0)
```