### PR TITLE
dijit.form.MappedTextBox.validate does take any parameters

### DIFF
--- a/dijit/1.11/form.d.ts
+++ b/dijit/1.11/form.d.ts
@@ -1560,7 +1560,7 @@ declare namespace dijit {
 			postMixInProperties(): void;
 			serialize: SerializationFunction;
 			toString(): string;
-			validate(isFocused: boolean): boolean;
+			validate(isFocused?: boolean): boolean;
 			buildRendering(): void;
 			reset(): void;
 		}


### PR DESCRIPTION
See [dijit/form/MappedTextBox.js#L57](https://github.com/dojo/dijit/blob/master/form/MappedTextBox.js#L57). In theory this should be 

```javascript
validate(): boolean;
```

but because `MappedTextBox.validate` calls `ValidationTextBox.validate` with `arguments` it's probably better to keep the parameter but make it optional.

```typescript
interface ValidationTextBox<C extends Constraints> extends TextBox {
	validate(isFocused: boolean): boolean;
}
```
