### PR TITLE
_WidgetBase.placeAt does not return the correct widget type

### DIFF
--- a/dijit/1.11/dijit.d.ts
+++ b/dijit/1.11/dijit.d.ts
@@ -760,7 +760,7 @@ declare namespace dijit {
 		 * Place this widget somewhere in the DOM based
 		 * on standard domConstruct.place() conventions.
 		 */
-		placeAt<T extends _WidgetBase>(reference: dojo.NodeFragmentOrString | T, position?: string | number): _WidgetBase;
+		placeAt<T extends _WidgetBase>(reference: dojo.NodeFragmentOrString | T, position?: string | number): this;
 
 		/**
 		 * Wrapper to setTimeout to avoid deferred functions executing


### PR DESCRIPTION
placeAt should return the type of widget that inherits it, instead of always returning `_WidgetBase`