### PR TITLE
Add _destroyed property to dijit.Destroyable

### DIFF
--- a/dijit/1.11/dijit.d.ts
+++ b/dijit/1.11/dijit.d.ts
@@ -1092,6 +1092,7 @@ declare namespace dijit {
 	/* dijit/Destroyable */
 
 	interface Destroyable {
+		_destroyed?: true;
 
 		/**
 		 * Destroy this class, releasing any resources registered via own().


### PR DESCRIPTION
If `_destroyed` exists on `dijit.Destroyable` then it's value will always be true.

https://github.com/dojo/dijit/blob/master/Destroyable.js#L21