### PR TITLE
Fixing _WidgetBase

### DIFF
--- a/dijit/1.11/dijit.d.ts
+++ b/dijit/1.11/dijit.d.ts
@@ -6,11 +6,6 @@ declare namespace dijit {
 
 	/* tslint:disable:class-name */
 
-	interface _WidgetBase extends dojo.Stateful, Destroyable {
-		dojoAttachEvent: string;
-		dojoAttachPoint: string;
-	}
-
 	interface _AttachMixin {
 		/**
 		 * List of widget attribute names associated with data-dojo-attach-point=... in the template, ex: ["containerNode", "labelNode"]
@@ -81,8 +76,7 @@ declare namespace dijit {
 
 	/* dijit/_BidiMixin */
 
-	interface _WidgetBase extends dojo.Stateful, Destroyable {
-
+	interface _BidiMixin {
 		/**
 		 * Gets the right direction of text.
 		 */
@@ -225,9 +219,7 @@ declare namespace dijit {
 	}
 
 	/* dijit/_FocusMixin */
-	interface _FocusMixin { }
-
-	interface _WidgetBase extends dojo.Stateful, Destroyable {
+	interface _FocusMixin extends _WidgetBase {
 		/**
 		 * Called when the widget becomes "active" because
 		 * it or a widget inside of it either has focus, or has recently
@@ -546,6 +538,15 @@ declare namespace dijit {
 
 	/* dijit/_WidgetBase */
 	interface _WidgetBase extends dojo.Stateful, Destroyable {
+		/**
+		 * This comes from the _AttachMixin extending _WidgetBase
+		 */
+		dojoAttachEvent?: string;
+
+		/**
+		 * This comes from the _AttachMixin extending _WidgetBase
+		 */
+		dojoAttachPoint?: string;
 
 		/**
 		 * A unique, opaque ID string that can be assigned by users or by the

--- a/dijit/1.11/form.d.ts
+++ b/dijit/1.11/form.d.ts
@@ -1163,6 +1163,7 @@ declare namespace dijit {
 		/* dijit/form/ComboBox */
 
 		interface ComboBox<T extends Object, Q extends dojo.store.api.BaseQueryType, O extends dojo.store.api.QueryOptions, C extends Constraints> extends ValidationTextBox<C>, ComboBoxMixin<T, Q, O> {
+			get(name: string): any;
 			set(name: string, value: any): this;
 			set(values: Object): this;
 		}
@@ -1201,6 +1202,9 @@ declare namespace dijit {
 			cssStateNodes: CSSStateNodes;
 			postMixInProperties(): void;
 			buildRendering(): void;
+
+			set(name: string, value: any): this;
+			set(values: Object): this;
 		}
 
 		interface ComboBoxMixinConstructor<T, U, V> extends _WidgetBaseConstructor<ComboBoxMixin<T, U, V>> { }
@@ -1299,6 +1303,9 @@ declare namespace dijit {
 			 * the _FormWidget mixin.
 			 */
 			isFocusable(): boolean;
+
+			set(name: string, value: any): this;
+			set(values: Object): this;
 		}
 
 		interface DropDownButtonConstructor extends _WidgetBaseConstructor<DropDownButton<any>> {
@@ -1325,6 +1332,8 @@ declare namespace dijit {
 
 			_openResultList(results: T[], query: Q, options: O): void;
 			undo(): void;
+
+			get(name: string): any;
 
 			set(name: 'displayedValue', value: string): this;
 			set(name: 'item', value: T): this;


### PR DESCRIPTION
After noticing there were 4 `_WidgetBase` interfaces I did some digging and found two of them were actually misnamed definitions for `_FocusMixin` and `_BidiMixin`. I merged the other two into a single `_WidgetBase` interface.