### PR TITLE
Enhance dojo/errors/create signature with optional arguments.

### DIFF
--- a/dojo/1.11/errors.d.ts
+++ b/dojo/1.11/errors.d.ts
@@ -20,6 +20,8 @@ declare namespace dojo {
 		interface Create {
 			<E extends Error, P extends Object>(name: string, ctor: GenericConstructor<any>, base: E, props: P): ErrorCtor<E & P>;
 			<E extends Error, P extends Object>(name: string, ctor: GenericConstructor<any>, base: E): ErrorCtor<E>;
+			<E extends Error, P extends Object>(name: string, ctor: GenericConstructor<any>): ErrorCtor<E>;
+			<E extends Error, P extends Object>(name: string): ErrorCtor<E>;
 		}
 
 		/* dojo/errors/RequestError */


### PR DESCRIPTION
Based on the [implementation](https://github.com/dojo/dojo/blob/b769bdc730d65aff8e83ac001b1edce1410b97ce/errors/create.js), all arguments, besides `name` should be optional.