### PR TITLE
Add type descriptor for module `dojo/i18n*`

### DIFF
--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -1052,6 +1052,8 @@ declare namespace dojo {
 		getL10nName(moduleName: string, bundleName: string, locale?: string): string;
 	}
 
+	type I18nBundle = { [s: string]: string | I18nBundle };
+
 	/* dojo/io-query */
 
 	interface IoQuery {

--- a/dojo/1.11/modules.d.ts
+++ b/dojo/1.11/modules.d.ts
@@ -814,7 +814,7 @@ declare module 'dojo/window' {
 }
 
 declare module 'dojo/i18n!*' {
-	const value: any;
+	const value: dojo.I18nBundle;
 	export = value;
 }
 


### PR DESCRIPTION
This adds a type `dojo.I18nBundle` and assigns that type to i18n bundles pulled in via dojo/i18n.
```
type I18nBundle = { [s: string]: string | I18nBundle };
```

When using it:
```
import i18n = require("dojo/i18n!./nls/Component");

//type of `i18n` is `dojo.I18nBundle`
```