### PR TITLE
added 2nd parameter for Stateful.set

### DIFF
--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -1949,7 +1949,7 @@ declare namespace dojo {
 		/**
 		 * Set a property on a Stateful instance
 		 */
-		set(name: string, value: any): this;
+		set(name: string, value: any, value2: any): this;
 		set(name: Object): this;
 
 		/**


### PR DESCRIPTION
in Javascript its possible to pass more than one parameter to this.set
e.g. this.set("item", bNoChange)
the typescript typings wont accept this since there is only one value parameter