### PR TITLE
Expanding Stateful set type to include multiple arguments

### DIFF
--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -1950,6 +1950,7 @@ declare namespace dojo {
 		 * Set a property on a Stateful instance
 		 */
 		set(name: string, value: any): this;
+		set(name: string, ...values: any[]): this;
 		set(name: Object): this;
 
 		/**


### PR DESCRIPTION
As mentioned in https://github.com/dojo/typings/pull/156, `Stateful.set` can technically be called with multiple parameters, as seen here

https://github.com/dojo/dojo/blob/master/Stateful.js#L119-L121

Expanding the types to include any number of parameters.