### PR TITLE
Revert "Add type descriptor for module `dojo/i18n*` (#152)"

### DIFF
--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -1052,8 +1052,6 @@ declare namespace dojo {
 		getL10nName(moduleName: string, bundleName: string, locale?: string): string;
 	}
 
-	type I18nBundle = { [s: string]: string | I18nBundle };
-
 	/* dojo/io-query */
 
 	interface IoQuery {

--- a/dojo/1.11/modules.d.ts
+++ b/dojo/1.11/modules.d.ts
@@ -814,7 +814,7 @@ declare module 'dojo/window' {
 }
 
 declare module 'dojo/i18n!*' {
-	const value: dojo.I18nBundle;
+	const value: any;
 	export = value;
 }
 


### PR DESCRIPTION
This reverts commit 8979255958e369e4530e5c4f29c4a8ffc9c9a36f. It turns out that this messes with the types enough to make this example not work without typecasting,


```ts
@declare(DijitDialog)
class Dialog {
	title: string = messages.dialogTitle;
	content: string = messages.dialogContent;
}
```