### PR TITLE
Fixes the EventedConstructor to use the same return type

### DIFF
--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -789,7 +789,7 @@ declare namespace dojo {
 	}
 
 	interface EventedConstructor extends _base.DeclareConstructor<Evented> {
-		new (params?: Object): Evented;
+		new (params?: Object): Evented & _base.DeclareCreatedObject;
 	}
 
 	/* dojo/fx */


### PR DESCRIPTION
Fixes the EventedConstructor to use the same return type as DeclareConstructor<Evented>
#170 Fixes the EventedConstructor