### PR TITLE
Fixes the EventedConstructor to use the same return type

### DIFF
--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -789,7 +789,7 @@ declare namespace dojo {
 	}
 
 	interface EventedConstructor extends _base.DeclareConstructor<Evented> {
-		new (params?: Object): Evented;
+		new (params?: Object): Evented & _base.DeclareCreatedObject;
 	}
 
 	/* dojo/fx */

--- a/dojo/1.11/dojo.d.ts
+++ b/dojo/1.11/dojo.d.ts
@@ -789,6 +789,9 @@ declare namespace dojo {
 	}
 
 	interface EventedConstructor extends _base.DeclareConstructor<Evented> {
+		// While not technically accurate, it is necessary to add `_base.DeclareCreatedObject`
+		// to avoid errors when mixing in Evented using declare
+		// see https://github.com/dojo/typings/issues/170
 		new (params?: Object): Evented & _base.DeclareCreatedObject;
 	}
 


### PR DESCRIPTION
Fixes the EventedConstructor to use the same return type as DeclareConstructor<Evented>
#170 

(PS: I made a hickup with the author email in the previous PR)
