### PR TITLE
Build Error TS> 4.4 Cannot find name DocumentEvent

### DIFF
--- a/dijit/1.11/dijit.d.ts
+++ b/dijit/1.11/dijit.d.ts
@@ -442,62 +442,62 @@ declare namespace dijit {
 		/**
 		 * Connect to this function to receive notifications of mouse click events.
 		 */
-		onClick(event: DocumentEvent): void;
+		onClick(event: Event): void;
 
 		/**
 		 * Connect to this function to receive notifications of mouse double click events.
 		 */
-		onDblClick(event: DocumentEvent): void;
+		onDblClick(event: Event): void;
 
 		/**
 		 * Connect to this function to receive notifications of keys being pressed down.
 		 */
-		onKeyDown(event: DocumentEvent): void;
+		onKeyDown(event: Event): void;
 
 		/**
 		 * Connect to this function to receive notifications of printable keys being typed.
 		 */
-		onKeyPress(event: DocumentEvent): void;
+		onKeyPress(event: Event): void;
 
 		/**
 		 * Connect to this function to receive notifications of keys being released.
 		 */
-		onKeyUp(event: DocumentEvent): void;
+		onKeyUp(event: Event): void;
 
 		/**
 		 * Connect to this function to receive notifications of when the mouse button is pressed down.
 		 */
-		onMouseDown(event: DocumentEvent): void;
+		onMouseDown(event: Event): void;
 
 		/**
 		 * Connect to this function to receive notifications of when the mouse moves over nodes contained within this widget.
 		 */
-		onMouseMove(event: DocumentEvent): void;
+		onMouseMove(event: Event): void;
 
 		/**
 		 * Connect to this function to receive notifications of when the mouse moves off of nodes contained within this widget.
 		 */
-		onMouseOut(event: DocumentEvent): void;
+		onMouseOut(event: Event): void;
 
 		/**
 		 * Connect to this function to receive notifications of when the mouse moves onto nodes contained within this widget.
 		 */
-		onMouseOver(event: DocumentEvent): void;
+		onMouseOver(event: Event): void;
 
 		/**
 		 * Connect to this function to receive notifications of when the mouse moves off of this widget.
 		 */
-		onMouseLeave(event: DocumentEvent): void;
+		onMouseLeave(event: Event): void;
 
 		/**
 		 * Connect to this function to receive notifications of when the mouse moves onto this widget.
 		 */
-		onMouseEnter(event: DocumentEvent): void;
+		onMouseEnter(event: Event): void;
 
 		/**
 		 * Connect to this function to receive notifications of when the mouse button is released.
 		 */
-		onMouseUp(event: DocumentEvent): void;
+		onMouseUp(event: Event): void;
 
 		postCreate(): void;
 

--- a/dijit/1.11/form.d.ts
+++ b/dijit/1.11/form.d.ts
@@ -148,8 +148,8 @@ declare namespace dijit {
 			 * Callback for when button is clicked.
 			 * If type="submit", return true to perform submit, or false to cancel it.
 			 */
-			onClick(e: DocumentEvent): boolean;
-			onSetLabel(e: DocumentEvent): void;
+			onClick(e: Event): boolean;
+			onSetLabel(e: Event): void;
 		}
 
 		/* dijit/form/_CheckBoxMixin */
@@ -1070,7 +1070,7 @@ declare namespace dijit {
 			 * Note that although for historical reasons this method is called `onInput()`, it doesn't
 			 * correspond to the standard DOM "input" event, because it occurs before the input has been processed.
 			 */
-			onInput(e: DocumentEvent): void;
+			onInput(e: Event): void;
 
 			postCreate(): void;
 
@@ -1132,9 +1132,9 @@ declare namespace dijit {
 			templateString: string;
 			postCreate(): void;
 			setLabel(content: string): void;
-			onLabelSet(e: DocumentEvent): void;
+			onLabelSet(e: Event): void;
 
-			onClick(e: DocumentEvent): boolean;
+			onClick(e: Event): boolean;
 
 			set(name: 'showLabel', value: boolean): this;
 			set(name: 'value', value: string): this;


### PR DESCRIPTION
https://github.com/dojo/typings/issues/184

DocumentEvent is no longer in versions 4.4 onwards of typescript. To me it looks like these should have been Event anyway? 
The interface for event can be seen at:
https://github.com/microsoft/TypeScript/blob/main/lib/lib.dom.d.ts#L5034

The previous interface for document event which it was using can be seen at

https://github.com/microsoft/TypeScript/blob/release-4.3/lib/lib.dom.d.ts#L4908

This PR changes just that issue e.g

```
onClick(e: DocumentEvent): boolean;
```
Becomes

```
onClick(e: Event): boolean;
```